### PR TITLE
Declare %result as Duration:D to match the return type

### DIFF
--- a/lib/Benchmark.rakumod
+++ b/lib/Benchmark.rakumod
@@ -24,7 +24,7 @@ my multi sub timethis(PIntD $count, &code, Bool :$statistics! where *.so --> Has
     my $mean = Duration.new: @exec-times.sum / $count;
     my $sd = Duration.new: sqrt( @exec-times.map( { ($_ - $mean)**2 } ).sum / $count);
 
-    my Duration %result = :$mean, :$median, :$min, :$max, :$sd;
+    my Duration:D %result = :$mean, :$median, :$min, :$max, :$sd;
     return %result;
 }
 


### PR DESCRIPTION
timethis declares its return type as Hash:D[Duration:D] but built the result with my Duration %result, which types as Hash[Duration]. Those parameterizations do not smartmatch, so the return-value type check fails. The legacy optimizer skipped the parameterized nominal check on the return value, so this went unnoticed; RakuAST enforces it.

Constrain the value type to Duration:D so %result types as Hash[Duration:D] and passes the check on both frontends.